### PR TITLE
feat: Add exception-like call stack format support

### DIFF
--- a/Serilog.Enrichers.CallStack/CallStackEnricherConfiguration.cs
+++ b/Serilog.Enrichers.CallStack/CallStackEnricherConfiguration.cs
@@ -111,6 +111,27 @@ public class CallStackEnricherConfiguration
     public int FrameOffset { get; set; } = 0;
 
     /// <summary>
+    /// Gets or sets the maximum number of call stack frames to include in the formatted call stack.
+    /// Default is 5. Set to -1 for unlimited frames.
+    /// </summary>
+    public int MaxFrames { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets whether to use the new exception-like call stack format.
+    /// When true, outputs a single "CallStack" property with formatted call stack.
+    /// When false, uses the legacy format with separate properties.
+    /// Default is true.
+    /// </summary>
+    public bool UseExceptionLikeFormat { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the property name for the formatted call stack.
+    /// Only used when UseExceptionLikeFormat is true.
+    /// Default is "CallStack".
+    /// </summary>
+    public string CallStackPropertyName { get; set; } = "CallStack";
+
+    /// <summary>
     /// Gets or sets whether to suppress exceptions that occur during enrichment.
     /// Default is true.
     /// </summary>
@@ -278,6 +299,25 @@ public class CallStackEnricherConfiguration
     {
         IncludeMethodParameters = includeParameters;
         UseFullParameterTypes = useFullParameterTypes;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the call stack format and depth.
+    /// </summary>
+    /// <param name="useExceptionLikeFormat">Whether to use exception-like format (single CallStack property).</param>
+    /// <param name="maxFrames">Maximum number of frames to include (-1 for unlimited).</param>
+    /// <param name="callStackPropertyName">Property name for the call stack.</param>
+    /// <returns>This configuration instance for method chaining.</returns>
+    public CallStackEnricherConfiguration WithCallStackFormat(
+        bool useExceptionLikeFormat = true,
+        int maxFrames = 5,
+        string? callStackPropertyName = null)
+    {
+        UseExceptionLikeFormat = useExceptionLikeFormat;
+        MaxFrames = maxFrames;
+        if (!string.IsNullOrEmpty(callStackPropertyName))
+            CallStackPropertyName = callStackPropertyName;
         return this;
     }
 }


### PR DESCRIPTION
## Summary
This PR introduces a new exception-like call stack format that provides a more intuitive and readable way to display call stack information in logs.

## Key Features
- **New Default Format**: Exception-like call stack display (e.g., `Method:Line --> Method:Line --> Method:Line`)
- **Single Property**: Consolidates call stack into one `CallStack` property instead of multiple separate properties
- **Configurable Depth**: `MaxFrames` setting to limit call stack depth (default: 5)
- **Backward Compatibility**: Legacy format still available via `useExceptionLikeFormat: false`

## Configuration Options
- `WithCallStackFormat(useExceptionLikeFormat, maxFrames, callStackPropertyName)`
- Toggle between new and legacy formats
- Configurable frame depth and property naming

## Example Output

**New Format (Default):**
```
CallStack: "Program.TestMethod3:30 --> Program.TestMethod2:25 --> Program.TestMethod1:20"
```

**Legacy Format:**
```
MethodName: "TestMethod3", TypeName: "Program", LineNumber: 30
```

## Changes Made
- Enhanced `CallStackEnricherConfiguration` with new format options
- Refactored `CallStackEnricher` to support both formats
- Added comprehensive tests for new functionality
- Updated existing tests to work with new default format
- Maintained full backward compatibility

## Testing
- All 33 tests pass
- Added specific tests for new exception-like format
- Tested both new and legacy formats
- Verified configuration options work correctly

## Breaking Changes
- **Default behavior changed**: New installations will use exception-like format by default
- **Migration**: Existing users who want the old format can use `.WithCallStackFormat(useExceptionLikeFormat: false)`